### PR TITLE
Add Bureau en Gros scraper workflow and data

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ Deploy-ready static site (GitHub Pages / Vercel).
 
 ## Features
 - Bilingual UI (FR/EN) via simple toggle.
-- Loads normalized data from `data/walmart_clean.json` and `data/toysrus_clean.json`.
+- Loads normalized data from `data/walmart_clean.json`, `data/toysrus_clean.json`, and `data/bureau_en_gros_liquidations.json`.
 - Filters: store, category, min % off, search.
 - Links to **Amazon**, **eBay**, and **Keepa** searches for each product.
 - RONA gallery page included in `pages/rona_gallery.html` (copied from your upload).
+- Bureau en Gros scraper workflow writes JSON + CSV clearance datasets.
 
 ## Local Dev
 Open `index.html` directly, or serve locally (recommended):
@@ -16,6 +17,26 @@ Open `index.html` directly, or serve locally (recommended):
 python -m http.server 8000
 # then open http://localhost:8000
 ```
+
+## Bureau en Gros scraper workflow
+
+Generate fresh clearance datasets (JSON + CSV) for Bureau en Gros:
+
+```bash
+# Parse the included fixture (works offline)
+python scripts/bureau_en_gros_scraper.py \
+  --input fixtures/bureau_en_gros_liquidation.html \
+  --json-out data/bureau_en_gros_liquidations.json \
+  --csv-out data/bureau_en_gros_liquidations.csv
+
+# Or scrape the live clearance page (requires internet access)
+python scripts/bureau_en_gros_scraper.py \
+  --url https://www.bureauengros.com/fr/clearance \
+  --json-out data/bureau_en_gros_liquidations.json \
+  --csv-out data/bureau_en_gros_liquidations.csv
+```
+
+The outputs are consumed automatically by `assets/js/app.js` (store filter will show "Bureau en Gros").
 
 ## GitHub Pages
 1. Create a new repo (e.g., `econodeal-landing`).

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -3,7 +3,7 @@
 const I18N = {
   fr: {
     title: "EconoDeal – Les meilleures liquidations au Canada",
-    subtitle: "Explorez les rabais de Walmart, Toys“R”Us, RONA – avec liens Amazon, eBay et Keepa.",
+    subtitle: "Explorez les rabais de Walmart, Toys“R”Us, RONA et Bureau en Gros – avec liens Amazon, eBay et Keepa.",
     search: "Rechercher un produit…",
     store: "Magasin",
     category: "Catégorie",
@@ -16,7 +16,7 @@ const I18N = {
   },
   en: {
     title: "EconoDeal – The best clearance deals in Canada",
-    subtitle: "Browse deals from Walmart, Toys“R”Us, RONA — with Amazon, eBay and Keepa links.",
+    subtitle: "Browse deals from Walmart, Toys“R”Us, RONA, and Bureau en Gros — with Amazon, eBay and Keepa links.",
     search: "Search products…",
     store: "Store",
     category: "Category",
@@ -35,7 +35,8 @@ function t(key){ return I18N[LANG][key] || key }
 // Data sources
 const DS = {
   walmart: fetch("./data/walmart_clean.json").then(r => r.json()).catch(_ => []),
-  toys: fetch("./data/toysrus_clean.json").then(r => r.json()).catch(_ => [])
+  toys: fetch("./data/toysrus_clean.json").then(r => r.json()).catch(_ => []),
+  bureau: fetch("./data/bureau_en_gros_liquidations.json").then(r => r.json()).catch(_ => [])
 };
 
 function encode(q){ return encodeURIComponent(q || "") }
@@ -141,7 +142,7 @@ function renderUI(deals){
 }
 
 async function boot(){
-  const deals = [...await DS.walmart, ...await DS.toys];
+  const deals = [...await DS.walmart, ...await DS.toys, ...await DS.bureau];
   renderUI(deals);
 }
 boot();

--- a/data/bureau_en_gros_liquidations.csv
+++ b/data/bureau_en_gros_liquidations.csv
@@ -1,0 +1,4 @@
+store,category,name,price,regular_price,product_url,image_url,sku,availability
+Bureau en Gros,Mobilier de bureau,Chaise ergonomique en maille Dalton,$149.97,$289.99,https://www.bureauengros.com/fr/chaise-ergonomique-en-maille-dalton/BI1001.html,https://assets.bureauengros.local/images/dalton-chair.jpg,BG-1001,En stock
+Bureau en Gros,Mobilier de bureau / Postes de travail,Bureau assis-debout électrique Altitude,$399.99,$699.99,https://www.bureauengros.com/fr/bureau-assis-debout-electrique-altitude/BI2040.html,https://assets.bureauengros.local/images/altitude-desk.jpg,BG-2040,Stock limité
+Bureau en Gros,Accessoires > Moniteurs,"Support double écran articulé Flex 27""",$89.99,$199.99,https://www.bureauengros.com/fr/support-double-ecran-articule-flex-27/BI3325.html,https://assets.bureauengros.local/images/flex-monitor-arm.jpg,BG-3325,En magasin seulement

--- a/data/bureau_en_gros_liquidations.json
+++ b/data/bureau_en_gros_liquidations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "store": "Bureau en Gros",
+    "category": "Mobilier de bureau",
+    "name": "Chaise ergonomique en maille Dalton",
+    "price": "$149.97",
+    "regular_price": "$289.99",
+    "product_url": "https://www.bureauengros.com/fr/chaise-ergonomique-en-maille-dalton/BI1001.html",
+    "image_url": "https://assets.bureauengros.local/images/dalton-chair.jpg",
+    "sku": "BG-1001",
+    "availability": "En stock"
+  },
+  {
+    "store": "Bureau en Gros",
+    "category": "Mobilier de bureau / Postes de travail",
+    "name": "Bureau assis-debout électrique Altitude",
+    "price": "$399.99",
+    "regular_price": "$699.99",
+    "product_url": "https://www.bureauengros.com/fr/bureau-assis-debout-electrique-altitude/BI2040.html",
+    "image_url": "https://assets.bureauengros.local/images/altitude-desk.jpg",
+    "sku": "BG-2040",
+    "availability": "Stock limité"
+  },
+  {
+    "store": "Bureau en Gros",
+    "category": "Accessoires > Moniteurs",
+    "name": "Support double écran articulé Flex 27\"",
+    "price": "$89.99",
+    "regular_price": "$199.99",
+    "product_url": "https://www.bureauengros.com/fr/support-double-ecran-articule-flex-27/BI3325.html",
+    "image_url": "https://assets.bureauengros.local/images/flex-monitor-arm.jpg",
+    "sku": "BG-3325",
+    "availability": "En magasin seulement"
+  }
+]

--- a/fixtures/bureau_en_gros_liquidation.html
+++ b/fixtures/bureau_en_gros_liquidation.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Liquidation Bureau en Gros</title>
+</head>
+<body>
+  <script id="__NEXT_DATA__" type="application/json">
+  {
+    "props": {
+      "pageProps": {
+        "pageData": {
+          "results": [
+            {
+              "name": "Chaise ergonomique en maille Dalton",
+              "sku": "BG-1001",
+              "salePrice": 149.97,
+              "listPrice": 289.99,
+              "image": "https://assets.bureauengros.local/images/dalton-chair.jpg",
+              "url": "/fr/chaise-ergonomique-en-maille-dalton/BI1001.html",
+              "category": "Mobilier de bureau",
+              "availability": "En stock"
+            },
+            {
+              "name": "Bureau assis-debout électrique Altitude",
+              "sku": "BG-2040",
+              "salePrice": 399.99,
+              "listPrice": 699.99,
+              "imageUrl": "https://assets.bureauengros.local/images/altitude-desk.jpg",
+              "productUrl": "/fr/bureau-assis-debout-electrique-altitude/BI2040.html",
+              "category": ["Mobilier de bureau", "Postes de travail"],
+              "availabilityStatus": "Stock limité"
+            },
+            {
+              "title": "Support double écran articulé Flex 27\"",
+              "id": "BG-3325",
+              "offerPrice": "89.99",
+              "regularPrice": "199.99",
+              "images": [
+                "https://assets.bureauengros.local/images/flex-monitor-arm.jpg"
+              ],
+              "pdpUrl": "/fr/support-double-ecran-articule-flex-27/BI3325.html",
+              "categoryPath": "Accessoires > Moniteurs",
+              "stockMessage": "En magasin seulement"
+            }
+          ]
+        }
+      }
+    }
+  }
+  </script>
+</body>
+</html>

--- a/scripts/bureau_en_gros_scraper.py
+++ b/scripts/bureau_en_gros_scraper.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Bureau en Gros clearance scraper.
+
+Usage:
+  python scripts/bureau_en_gros_scraper.py --url https://www.bureauengros.com/fr/clearance
+  python scripts/bureau_en_gros_scraper.py --input fixtures/bureau_en_gros_liquidation.html
+
+Outputs JSON and CSV files with normalized fields consumed by the landing page.
+The scraper relies on JSON embedded in the page (e.g., Next.js `__NEXT_DATA__`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+
+STORE_NAME = "Bureau en Gros"
+
+
+@dataclass
+class Product:
+    name: str
+    price: Optional[str]
+    regular_price: Optional[str]
+    product_url: Optional[str]
+    image_url: Optional[str]
+    category: Optional[str]
+    availability: Optional[str]
+    sku: Optional[str]
+    store: str = STORE_NAME
+
+    def to_mapping(self) -> Dict[str, Optional[str]]:
+        return {
+            "store": self.store,
+            "category": self.category,
+            "name": self.name,
+            "price": self.price,
+            "regular_price": self.regular_price,
+            "product_url": self.product_url,
+            "image_url": self.image_url,
+            "sku": self.sku,
+            "availability": self.availability,
+        }
+
+
+class BureauEnGrosScraper:
+    def __init__(self, base_url: str = "https://www.bureauengros.com") -> None:
+        self.base_url = base_url.rstrip("/")
+
+    # --------------------------- HTTP / IO helpers ---------------------------
+    def fetch_url(self, url: str) -> str:
+        request = Request(url, headers={"User-Agent": "Mozilla/5.0 (scraper)"})
+        try:
+            with urlopen(request, timeout=20) as resp:  # nosec: B310 - trusted target configured by user
+                charset = resp.headers.get_content_charset() or "utf-8"
+                return resp.read().decode(charset, errors="replace")
+        except HTTPError as exc:  # pragma: no cover - exercised only online
+            raise RuntimeError(f"HTTP error {exc.code} for {url}") from exc
+        except URLError as exc:  # pragma: no cover - exercised only online
+            raise RuntimeError(f"Network error for {url}: {exc.reason}") from exc
+
+    def load_source(self, url: Optional[str], input_path: Optional[Path]) -> str:
+        if input_path:
+            return Path(input_path).read_text(encoding="utf-8")
+        if url:
+            return self.fetch_url(url)
+        raise ValueError("Provide either --url or --input")
+
+    # -------------------------- Parsing / extraction -------------------------
+    @staticmethod
+    def _extract_json_strings(html: str) -> Iterable[str]:
+        script_pattern = re.compile(r'<script[^>]*type="application/json"[^>]*>(.*?)</script>', re.S)
+        next_data_pattern = re.compile(r"__NEXT_DATA__\s*=\s*({.*?})\s*<", re.S)
+        preloaded_pattern = re.compile(r"__PRELOADED_STATE__\s*=\s*({.*?})\s*;", re.S)
+
+        for regex in (script_pattern, next_data_pattern, preloaded_pattern):
+            for match in regex.findall(html):
+                yield match.strip()
+
+    @staticmethod
+    def _to_float(value: Any) -> Optional[float]:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            cleaned = re.sub(r"[^\d.,-]", "", value).replace(",", ".")
+            try:
+                return float(cleaned)
+            except ValueError:
+                return None
+        return None
+
+    def _format_price(self, value: Any) -> Optional[str]:
+        number = self._to_float(value)
+        if number is None:
+            return None
+        return f"${number:.2f}"
+
+    @staticmethod
+    def _looks_like_product(obj: Any) -> bool:
+        if not isinstance(obj, dict):
+            return False
+        has_name = any(k in obj for k in ("name", "title"))
+        has_price = any(k in obj for k in ("salePrice", "offerPrice", "price", "currentPrice", "regularPrice", "listPrice"))
+        return has_name and has_price
+
+    def _find_product_nodes(self, obj: Any) -> Iterable[Dict[str, Any]]:
+        if isinstance(obj, list):
+            for item in obj:
+                yield from self._find_product_nodes(item)
+        elif isinstance(obj, dict):
+            if self._looks_like_product(obj):
+                yield obj
+            for value in obj.values():
+                yield from self._find_product_nodes(value)
+
+    def _first_non_null(self, obj: Dict[str, Any], keys: Iterable[str]) -> Any:
+        for key in keys:
+            if key in obj and obj[key] not in (None, ""):
+                return obj[key]
+        return None
+
+    def _normalize_product(self, raw: Dict[str, Any]) -> Optional[Product]:
+        name = self._first_non_null(raw, ("name", "title"))
+        if not name:
+            return None
+
+        price = self._format_price(self._first_non_null(raw, (
+            "salePrice",
+            "offerPrice",
+            "price",
+            "currentPrice",
+            "activePrice",
+        )))
+        regular_price = self._format_price(self._first_non_null(raw, (
+            "listPrice",
+            "regularPrice",
+            "wasPrice",
+        )))
+
+        sku = self._first_non_null(raw, ("sku", "id", "itemId", "partNumber"))
+        product_url = self._first_non_null(raw, ("product_url", "productUrl", "url", "pdpUrl"))
+        if isinstance(product_url, str) and product_url.startswith("/"):
+            product_url = urljoin(self.base_url, product_url)
+
+        image_candidates = self._first_non_null(raw, (
+            "image",
+            "imageUrl",
+            "thumbnail",
+            "primaryImage",
+            "image_url",
+            "images",
+        ))
+        image_url: Optional[str] = None
+        if isinstance(image_candidates, list):
+            image_url = image_candidates[0]
+        else:
+            image_url = image_candidates
+
+        category = self._first_non_null(raw, ("category", "categoryPath", "categoryName"))
+        if isinstance(category, list):
+            category = " / ".join(str(c) for c in category)
+
+        availability = self._first_non_null(raw, ("availability", "availabilityStatus", "stockMessage", "inventoryStatus"))
+
+        return Product(
+            name=str(name).strip(),
+            price=price,
+            regular_price=regular_price,
+            product_url=product_url,
+            image_url=image_url,
+            category=category,
+            availability=availability,
+            sku=str(sku) if sku is not None else None,
+        )
+
+    def parse_products(self, html: str) -> List[Product]:
+        products: List[Product] = []
+        for block in self._extract_json_strings(html):
+            try:
+                data = json.loads(block)
+            except json.JSONDecodeError:
+                continue
+            for raw in self._find_product_nodes(data):
+                product = self._normalize_product(raw)
+                if product:
+                    products.append(product)
+
+        # Deduplicate by SKU/name + price
+        deduped: Dict[str, Product] = {}
+        for item in products:
+            key = item.sku or f"{item.name}|{item.price}"
+            deduped[key] = item
+        return list(deduped.values())
+
+    # ------------------------------- Public API ------------------------------
+    def scrape(self, url: Optional[str] = None, input_path: Optional[Path] = None) -> List[Product]:
+        html = self.load_source(url=url, input_path=input_path)
+        return self.parse_products(html)
+
+
+def write_json(path: Path, products: List[Product]) -> None:
+    payload = [p.to_mapping() for p in products]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_csv(path: Path, products: List[Product]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ["store", "category", "name", "price", "regular_price", "product_url", "image_url", "sku", "availability"]
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for product in products:
+            writer.writerow({k: v or "" for k, v in product.to_mapping().items()})
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Scrape Bureau en Gros liquidation products.")
+    parser.add_argument("--url", help="Page URL to scrape (liquidation / clearance).")
+    parser.add_argument("--input", type=Path, help="Local HTML file to parse instead of fetching.")
+    parser.add_argument("--json-out", type=Path, default=Path("data/bureau_en_gros_liquidations.json"), help="Path to write JSON output.")
+    parser.add_argument("--csv-out", type=Path, default=Path("data/bureau_en_gros_liquidations.csv"), help="Path to write CSV output.")
+    parser.add_argument("--base-url", default="https://www.bureauengros.com", help="Base URL used to resolve relative product links.")
+
+    args = parser.parse_args(argv)
+    scraper = BureauEnGrosScraper(base_url=args.base_url)
+
+    products = scraper.scrape(url=args.url, input_path=args.input)
+    if not products:
+        print("No products extracted", file=sys.stderr)
+        return 1
+
+    write_json(args.json_out, products)
+    write_csv(args.csv_out, products)
+
+    print(f"Extracted {len(products)} products → {args.json_out} / {args.csv_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Bureau en Gros scraping workflow with a reusable Python script and fixture
- publish generated Bureau en Gros liquidation datasets (JSON + CSV) for the frontend
- load the new dataset in the landing page copy and documentation

## Testing
- python scripts/bureau_en_gros_scraper.py --input fixtures/bureau_en_gros_liquidation.html --json-out data/bureau_en_gros_liquidations.json --csv-out data/bureau_en_gros_liquidations.csv

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e5be90ce0832e896358d68456f683)