### PR TITLE
Add manual workflow for Bureau en Gros scraper

### DIFF
--- a/.github/workflows/manual-bureau-en-gros-scrape.yml
+++ b/.github/workflows/manual-bureau-en-gros-scrape.yml
@@ -1,0 +1,52 @@
+name: Manual Bureau en Gros scrape
+
+on:
+  workflow_dispatch:
+    inputs:
+      url:
+        description: "Optional live clearance page URL to scrape; leave blank to parse the bundled fixture."
+        required: false
+        default: ""
+      json_out:
+        description: "Filename for the JSON dataset artifact."
+        required: false
+        default: "bureau_en_gros_liquidations.json"
+      csv_out:
+        description: "Filename for the CSV dataset artifact."
+        required: false
+        default: "bureau_en_gros_liquidations.csv"
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run Bureau en Gros scraper
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          if [ -n "${{ inputs.url }}" ]; then
+            SRC_FLAG="--url ${{ inputs.url }}"
+          else
+            SRC_FLAG="--input fixtures/bureau_en_gros_liquidation.html"
+          fi
+
+          python scripts/bureau_en_gros_scraper.py \
+            ${SRC_FLAG} \
+            --json-out "artifacts/${{ inputs.json_out }}" \
+            --csv-out "artifacts/${{ inputs.csv_out }}"
+
+      - name: Upload datasets
+        uses: actions/upload-artifact@v4
+        with:
+          name: bureau-en-gros-datasets
+          path: artifacts/
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ python scripts/bureau_en_gros_scraper.py \
 
 The outputs are consumed automatically by `assets/js/app.js` (store filter will show "Bureau en Gros").
 
+### Manual GitHub Actions run
+
+If you prefer to generate datasets without using your local environment, trigger the **Manual Bureau en Gros scrape** workflow from the **Actions** tab. It accepts an optional `url` input (leave blank to parse the bundled fixture) and uploads the JSON/CSV outputs as downloadable artifacts.
+
 ## GitHub Pages
 1. Create a new repo (e.g., `econodeal-landing`).
 2. Upload all files from this zip to the root of the repo.


### PR DESCRIPTION
## Summary
- add a workflow_dispatch GitHub Actions job to run the Bureau en Gros scraper and upload JSON/CSV artifacts
- document how to trigger the manual workflow from the Actions tab

## Testing
- python scripts/bureau_en_gros_scraper.py --input fixtures/bureau_en_gros_liquidation.html --json-out /tmp/test.json --csv-out /tmp/test.csv

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e5e8d0af4832e8f028fe817b75cee)