### PR TITLE
Add Python dependency install step to scraper workflow

### DIFF
--- a/.github/workflows/manual-bureau-en-gros-scrape.yml
+++ b/.github/workflows/manual-bureau-en-gros-scrape.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
       - name: Run Bureau en Gros scraper
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- add a dependency installation step before running the Bureau en Gros scraper

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e610472bc832ea0e8def7a0c51bd9)